### PR TITLE
Fix H1s wrapping badly (the line-height causes text to overlap).

### DIFF
--- a/example/public/a/granita.less
+++ b/example/public/a/granita.less
@@ -485,7 +485,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Headings */
 h1 {
-  line-height: 0.57447em;
+  line-height: 1.14894em;
   font-size: 36px;
   margin: 27px 0;
 }


### PR DESCRIPTION
The Sorbet theme adds an additional class to post titles (entry-title) that overrides the line height.  Since Lanyon doesn't use that class, apply the proper height to the base H1 style.
